### PR TITLE
fix pem extension and file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Here is the list of generated files:
 
 **Format: PEM and server only (no mTLS)**
 
-- 🔑  Key File: $DIR/$NAME-key.pem
-- 📜  Cert File: $DIR/$NAME-cert.pem
-- 🔓  Trust Store File: $DIR/$NAME-truststore.pem (to be deployed on the client-side)
+- 🔑  Key File: $DIR/$NAME.key
+- 📜  Cert File: $DIR/$NAME.crt
+- 🔓  Trust Store File: $DIR/$NAME-ca.crt (to be deployed on the client-side)
 
 **Format: PKCS12 and server only (no mTLS)**
 
@@ -40,12 +40,12 @@ Here is the list of generated files:
 
 **Format: PEM and mTLS**
 
-- 🔑  Key File: $DIR/$NAME-key.pem (to be deployed on the server-side)
-- 📜  Cert File: $DIR/$NAME-cert.pem (to be deployed on the server-side)
-- 🔓  Server Trust Store File: $DIR/$NAME-server-truststore.pem (to be deployed on the server-side, contains the client certificate)
-- 🔑  Client Key File: $DIR/$NAME-client-key.pem (to be deployed on the client-side)
-- 📜  Client Cert File: $DIR/$NAME-client-cert.pem (to be deployed on the client-side)
-- 🔓  Client Trust Store File: $DIR/$NAME-client-truststore.pem (to be deployed on the client-side, contains the server certificate)
+- 🔑  Key File: $DIR/$NAME.key (to be deployed on the server-side)
+- 📜  Cert File: $DIR/$NAME.crt (to be deployed on the server-side)
+- 🔓  Server Trust Store File: $DIR/$NAME-server-ca.crt (to be deployed on the server-side, contains the client certificate)
+- 🔑  Client Key File: $DIR/$NAME-client.key (to be deployed on the client-side)
+- 📜  Client Cert File: $DIR/$NAME-client.crt (to be deployed on the client-side)
+- 🔓  Client Trust Store File: $DIR/$NAME-client-ca.crt (to be deployed on the client-side, contains the server certificate)
 
 
 **Format: PKCS12 and mTLS**

--- a/certificate-generator/src/main/java/me/escoffier/certs/CertificateGenerator.java
+++ b/certificate-generator/src/main/java/me/escoffier/certs/CertificateGenerator.java
@@ -41,12 +41,12 @@ public class CertificateGenerator {
 
             for (Format format : request.formats()) {
                 if (format == Format.PEM) {
-                    File certFile = new File(root, request.name() + "-cert.pem");
-                    File keyFile = new File(root, request.name() + "-key.pem");
-                    File trustfile = new File(root, request.name() + (client!=null ? "-client" : "") + "-truststore.pem");
-                    File clientCertFile = new File(root, request.name() + "-client-cert.pem");
-                    File clientKeyFile = new File(root, request.name() + "-client-key.pem");
-                    File serverTrustfile = new File(root, request.name() + "-server-truststore.pem");
+                    File certFile = new File(root, request.name() + ".crt");
+                    File keyFile = new File(root, request.name() + ".key");
+                    File trustfile = new File(root, request.name() + (client!=null ? "-client" : "") + "-ca.crt");
+                    File clientCertFile = new File(root, request.name() + "-client.crt");
+                    File clientKeyFile = new File(root, request.name() + "-client.key");
+                    File serverTrustfile = new File(root, request.name() + "-server-ca.crt");
 
                     writeCertificateToPEM(certificate, certFile);
                     writePrivateKeyToPem(keyPair.getPrivate(), keyFile);

--- a/certificate-generator/src/main/java/me/escoffier/certs/CertificateRequest.java
+++ b/certificate-generator/src/main/java/me/escoffier/certs/CertificateRequest.java
@@ -65,7 +65,7 @@ public final class CertificateRequest {
             throw new IllegalArgumentException("The name of the certificate must be set");
         }
         if (formats.isEmpty()) {
-            throw new IllegalArgumentException("At least one format must be set");
+            formats.add(Format.PEM);
         }
         if (cn == null || cn.isEmpty()) {
             cn = "localhost";

--- a/certificate-generator/src/test/java/me/escoffier/certs/GenerationTest.java
+++ b/certificate-generator/src/test/java/me/escoffier/certs/GenerationTest.java
@@ -67,9 +67,9 @@ public class GenerationTest {
         new CertificateGenerator(tempDir).generate(request);
 
         KeyCertOptions serverOptions = new PemKeyCertOptions()
-                .addKeyPath(new File(tempDir.toFile(), "test-key.pem").getAbsolutePath())
-                .addCertPath(new File(tempDir.toFile(), "test-cert.pem").getAbsolutePath());
-        TrustOptions clientOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-truststore.pem").getAbsolutePath());
+                .addKeyPath(new File(tempDir.toFile(), "test.key").getAbsolutePath())
+                .addCertPath(new File(tempDir.toFile(), "test.crt").getAbsolutePath());
+        TrustOptions clientOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-ca.crt").getAbsolutePath());
         var server = VertxHttpHelper.createHttpServer(vertx, serverOptions);
         var response = VertxHttpHelper.createHttpClientAndInvoke(vertx, server, clientOptions);
 
@@ -102,7 +102,7 @@ public class GenerationTest {
         new CertificateGenerator(tempDir).generate(request);
 
         KeyCertOptions serverOptions = new PfxOptions().setPath(new File(tempDir.toFile(), "test-keystore.p12").getAbsolutePath()).setPassword("password");
-        TrustOptions clientOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-truststore.pem").getAbsolutePath());
+        TrustOptions clientOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-ca.crt").getAbsolutePath());
         var server = VertxHttpHelper.createHttpServer(vertx, serverOptions);
         var response = VertxHttpHelper.createHttpClientAndInvoke(vertx, server, clientOptions);
 
@@ -118,14 +118,14 @@ public class GenerationTest {
         new CertificateGenerator(tempDir).generate(request);
 
         KeyCertOptions serverOptions = new PemKeyCertOptions()
-                .addKeyPath(new File(tempDir.toFile(), "test-key.pem").getAbsolutePath())
-                .addCertPath(new File(tempDir.toFile(), "test-cert.pem").getAbsolutePath());
-        PemTrustOptions serverTrustOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-server-truststore.pem").getAbsolutePath());
+                .addKeyPath(new File(tempDir.toFile(), "test.key").getAbsolutePath())
+                .addCertPath(new File(tempDir.toFile(), "test.crt").getAbsolutePath());
+        PemTrustOptions serverTrustOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-server-ca.crt").getAbsolutePath());
 
         KeyCertOptions clientOptions = new PemKeyCertOptions()
-                .addKeyPath(new File(tempDir.toFile(), "test-client-key.pem").getAbsolutePath())
-                .addCertPath(new File(tempDir.toFile(), "test-client-cert.pem").getAbsolutePath());
-        TrustOptions clientTrustOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-client-truststore.pem").getAbsolutePath());
+                .addKeyPath(new File(tempDir.toFile(), "test-client.key").getAbsolutePath())
+                .addCertPath(new File(tempDir.toFile(), "test-client.crt").getAbsolutePath());
+        TrustOptions clientTrustOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-client-ca.crt").getAbsolutePath());
         var server = VertxHttpHelper.createHttpServerWithMutualAuth(vertx, serverOptions, serverTrustOptions);
         var response = VertxHttpHelper.createHttpClientWithMutualAuthAndInvoke(vertx, server, clientOptions, clientTrustOptions);
 
@@ -194,9 +194,9 @@ public class GenerationTest {
         TrustOptions serverTrustOptions = new JksOptions().setPath(new File(tempDir.toFile(), "test-server-truststore.jks").getAbsolutePath()).setPassword("secret").setAlias("alias");
 
         KeyCertOptions clientOptions = new PemKeyCertOptions()
-                .addKeyPath(new File(tempDir.toFile(), "test-client-key.pem").getAbsolutePath())
-                .addCertPath(new File(tempDir.toFile(), "test-client-cert.pem").getAbsolutePath());
-        TrustOptions clientTrustOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-client-truststore.pem").getAbsolutePath());
+                .addKeyPath(new File(tempDir.toFile(), "test-client.key").getAbsolutePath())
+                .addCertPath(new File(tempDir.toFile(), "test-client.crt").getAbsolutePath());
+        TrustOptions clientTrustOptions = new PemTrustOptions().addCertPath(new File(tempDir.toFile(), "test-client-ca.crt").getAbsolutePath());
 
         var server = VertxHttpHelper.createHttpServerWithMutualAuth(vertx, serverOptions, serverTrustOptions);
         var response = VertxHttpHelper.createHttpClientWithMutualAuthAndInvoke(vertx, server, clientOptions, clientTrustOptions);


### PR DESCRIPTION
Follows extension recommendations for PEM files

- keys are .key
- certificates are .crt
- truststore are -ca.crt