### PR TITLE
Fix missing client certificate generation with junit5

### DIFF
--- a/certificate-generator-junit5/src/main/java/me/escoffier/certs/junit5/CertificateGenerationExtension.java
+++ b/certificate-generator-junit5/src/main/java/me/escoffier/certs/junit5/CertificateGenerationExtension.java
@@ -47,6 +47,7 @@ public class CertificateGenerationExtension implements BeforeAllCallback, Parame
 
             CertificateRequest request = new CertificateRequest()
                     .withName(certificate.name())
+                    .withClientCertificate(certificate.client())
                     .withFormats(Arrays.asList(certificate.formats()))
                     .withAlias(certificate.alias().isEmpty() ? null : certificate.alias())
                     .withCN(certificate.cn())


### PR DESCRIPTION
It was not possible to generate _client_ certificates using the juni5 extension.